### PR TITLE
Update version to 1.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "meson" %}
-{% set version = "1.10.1" %}
+{% set version = "1.11.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c42296f12db316a4515b9375a5df330f2e751ccdd4f608430d41d7d6210e4317
+  sha256: dffdd0915ceb028541fe3bed77d63ba35e78514591c043736b450d62634eeb31
   # See conda-forge/glib-feedstock#40 for documentation regarding the RPATH patch
   patches:
     - 0001-Only-fix-RPATH-if-install_rpath-is-not-empty.patch


### PR DESCRIPTION
meson 1.11.2

**Destination channel:**  defaults

### Links

- [PKG-16601](https://anaconda.atlassian.net/browse/PKG-16601) 
- [Upstream repository](https://github.com/mesonbuild/meson/blob/1.11.2/setup.py)

### Explanation of changes:
- New version number


[PKG-16601]: https://anaconda.atlassian.net/browse/PKG-16601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ