### PR TITLE
PKG-17338 — meson 1.11.0 py315 vs 3.15.0rc1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,14 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"
+  - "--no-test"
+
+upload_channels:
+  - ad-testing/label/py315
+
+channels:
+  - ad-testing/label/py315
+
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+  ANACONDA_ROCKET_ENABLE_PY315: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<315 or py>=316]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - meson = mesonbuild.mesonmain:main


### PR DESCRIPTION
**Destination channel:** ad-testing/label/py315

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-17338)
- [Upstream repository](https://github.com/mesonbuild/meson)

### Explanation of changes:

- Rebuild meson vs Python 3.15.0rc1 (host of meson-python / numpy-base).
- Skip: py<315 or py>=316.
- abs.yaml: testing channels, --no-test, ANACONDA_ROCKET_ENABLE_PY315.

### Notes:

- Targets `master-py3.15.0rc1`, not master.
- meson-python#21 failed without this (meson only through py314 on defaults).

Made with [Cursor](https://cursor.com)