### PR TITLE
meson 1.11.0: rebuild for free-threaded py314t

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,5 +3,5 @@ build_parameters:
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_FREETHREADING: yes
 channels:
-  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/9b1e75c
-  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/d27f75f
+  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/cac687d
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/4df3dd3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,7 @@
+build_parameters:
+  - "--no-test"
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+  ANACONDA_ROCKET_ENABLE_FREETHREADING: yes
+channels:
+  - https://staging.continuum.io/pbp/fs/setuptools-feedstock/pr109/9b1e75c
+  - https://staging.continuum.io/pbp/fs/flit-feedstock/pr23/d27f75f

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,0 @@
-# Until AnacondaRecipes/aggregate#534 merges: t-only overlay.
-python:
-  - "3.14.* *_cp314t"
-numpy:
-  - 2.3
-zip_keys:
-  -
-    - python
-    - numpy

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,9 @@
+# Until AnacondaRecipes/aggregate#534 merges: t-only overlay.
+python:
+  - "3.14.* *_cp314t"
+numpy:
+  - 2.3
+zip_keys:
+  -
+    - python
+    - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-Only-fix-RPATH-if-install_rpath-is-not-empty.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:


### PR DESCRIPTION
meson - rebuild for free-threaded Python 3.14

**Destination channel:** main

### Links
- [Jira](https://anaconda.atlassian.net/browse/PKG-17710)
- [Upstream repository](https://github.com/mesonbuild/meson)

### Explanation of changes:
- Rebuild this package for free-threaded Python 3.14
- Python 3.14.7 is already on main. We did not rebuild Python
- meson-python host needs meson with cp314t

### Notes:
- Please check staging for a `cp314t` or `py314t` artifact: https://staging.continuum.io/pbp/fs/meson-feedstock/pr26/3762582
- This graph is free-threaded py314t only. Before merge we will delete the python/numpy/zip_keys overlay from recipe/conda_build_config.yaml so master does not stay t-only.
- Tests skipped: pytest has no cp314t yet